### PR TITLE
added condition to catch timeout and raise warning

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -29,9 +29,9 @@
 
 .wcvp_fresh <- function() {
   wcvp_fresh <- try(rWCVPdata::wcvp_check_version(silent=TRUE), silent=TRUE)
-  
+
   timeout <- FALSE
-  if (class(wcvp_fresh) == "try-error") {
+  if (inherits(wcvp_fresh,"try-error")) {
     if (stringr::str_detect(wcvp_fresh[[1]], "Timeout was reached")) {
       timeout <- TRUE
       wcvp_fresh <- TRUE
@@ -39,7 +39,7 @@
       cli::cli_abort(wcvp_fresh[[1]])
     }
   }
-  
+
   if (rlang::env_has(.pkgenv, "wcvp_fresh")) {
     return(invisible(NULL))
   } else {

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -28,11 +28,31 @@
 }
 
 .wcvp_fresh <- function() {
-  wcvp_fresh <- rWCVPdata::wcvp_check_version(silent = TRUE)
+  wcvp_fresh <- try(rWCVPdata::wcvp_check_version(silent=TRUE), silent=TRUE)
+  
+  timeout <- FALSE
+  if (class(wcvp_fresh) == "try-error") {
+    if (stringr::str_detect(wcvp_fresh[[1]], "Timeout was reached")) {
+      timeout <- TRUE
+      wcvp_fresh <- TRUE
+    } else {
+      cli::cli_abort(wcvp_fresh[[1]])
+    }
+  }
+  
   if (rlang::env_has(.pkgenv, "wcvp_fresh")) {
     return(invisible(NULL))
   } else {
     .pkgenv[["wcvp_fresh"]] <- wcvp_fresh
+  }
+
+  if (timeout) {
+    cli::cli_warn(c(
+      "Unable to contact WCVP server at {.url http://sftp.kew.org/pub/data-repositories/WCVP},",
+      "please check your internet connection and the server site.",
+      "Assuming the WCVP data you have is up to date for now..."
+      )
+    )
   }
 
   if (!wcvp_fresh) {

--- a/README.Rmd
+++ b/README.Rmd
@@ -13,7 +13,7 @@ knitr::opts_chunk$set(
 )
 ```
 
-# rWCVP <a href="https://matildabrown.github.io/rWCVP/"><img src="man/figures/logo.png" align="right" height="138" /></a>
+# rWCVP <a href="https://matildabrown.github.io/rWCVP/"><img src="man/figures/logo.png" align="right" height="276" /></a>
 
 <!-- badges: start -->
 <!-- badges: start -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
 
-  # rWCVP
+# rWCVP <a href="https://matildabrown.github.io/rWCVP/"><img src="man/figures/logo.png" align="right" height="276" /></a>
 
 <!-- badges: start -->
 <!-- badges: start -->
@@ -13,7 +13,7 @@
 
 rWCVP is a package for accessing and using plant name and distribution
 data from the [World Checklist of Vascular
-Plants](https://powo.science.kew.org/about-wcvp)
+Plants](https://powo.science.kew.org//)
 
 ## Installation
 
@@ -33,11 +33,11 @@ species.
 ``` r
 library(rWCVP)
 
-distribution <- wcvp_distribution("Myrcia guianensis", taxon_rank="species")
+distribution <- wcvp_distribution("Myrcia guianensis", taxon_rank = "species")
 
 # global map
 wcvp_distribution_map(distribution)
 
 # zoomed-in map
-wcvp_distribution_map(distribution, crop_map=TRUE)
+wcvp_distribution_map(distribution, crop_map = TRUE)
 ```


### PR DESCRIPTION
Inserted a condition in `.wcvp_fresh` function to catch the timeout error and allow the user to proceed with a warning. I haven't checked if this breaks the build or tests yet but hopefully should be okay.

I thought it was better to add the check in rWCVP than rWCVPdata because the version check isn't integral to rWCVPdata functioning.

closes #59 and #58 